### PR TITLE
Clean up

### DIFF
--- a/docs/guides/web-push.md
+++ b/docs/guides/web-push.md
@@ -4,13 +4,8 @@ NotificationAPI supports sending web push notifications. While most notification
 
 ## Configuring Web Push Notifications
 
-Sending and displaying web push notifications work out-of-the-box with our libraries:
+Web push notifications are integrated with the front-end JS SDK. Please follow the setup instructions [here](../reference/js-client#setup).
 
-1. Setup our [front-end library ](../reference/js-client#setup)
    :::warning
-   The [Service Worker](../reference/js-client.md#service-worker-setup) integration is required for web push to work.
-   :::
+   The [Service Worker](../reference/js-client.md#service-worker-setup) is required to receive web push notifications.
 
-2. Initialize our [front-end library](../reference/js-client#initialization)
-
-3. Send notifications from the backend [backend](../reference/server#send)

--- a/docs/reference/js-client.md
+++ b/docs/reference/js-client.md
@@ -304,7 +304,7 @@ ngOnInit() {
 
 _Only required for Web Push notifications:_
 
-Download [this file](../../assets/files/notificationapi-service-worker.js) and place it in the "public" folder of your web application. For example, if you are using react, the file should go in the `public` folder.
+Download [notificationapi-service-worker.js](../../assets/files/notificationapi-service-worker.js) and place it in the "public" folder of your web application.
 
 ## getUserPreferences
 


### PR DESCRIPTION
- Seemed weird to list out steps when the user only needs to setup the frontend sdk
- Changed "this file" to "notificationapi-service-worker" so it seems less sketchy

Honestly there doesn't seem to be much to do here