### PR TITLE
Update merge tags size limit

### DIFF
--- a/docs/features/mergetags.md
+++ b/docs/features/mergetags.md
@@ -65,7 +65,7 @@ Some of the most valuable filters are:
 
 ## Size Limit
 
-When using parameters (merge tags) in the body of your notifications, it is recommended that the size of the combined parameters not exceed 80 KB. Exceeding this limit may result in delivery failure, or an API error.
+When using parameters (merge tags) in the body of your notifications, it is recommended that the size of the combined parameters not exceed 150 KB. Exceeding this limit may result in delivery failure, or an API error.
 
 ## Conditional Logic (if, else)
 

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -578,7 +578,7 @@ The send() method accepts an object with the following fields:
 | `fcm.android.ttl`         | string                                      | This parameter specifies how long (in seconds) the message should be kept in FCM storage if the device is offline. The maximum time to live supported is 4 weeks, and the default value is 4 weeks. For more information, see [Setting the lifespan of a message](https://firebase.google.com/docs/cloud-messaging/concept-options#ttl)                                                                                                                                                                                                                                                                                                                                                      |
 #### Size Limitation 
 
-When using parameters (merge tags) in the body of your notifications, it is recommended that the size of the combined parameters not exceed 80 KB. Exceeding this limit may result in delivery failure, or an API error.
+When using parameters (merge tags) in the body of your notifications, it is recommended that the size of the combined parameters not exceed 150 KB. Exceeding this limit may result in delivery failure, or an API error.
 
 ## identifyUser
 


### PR DESCRIPTION
Update documentation with the increased merge tag size limit of 150 KB, in the follow places:
- Features -> Parameters -> Size Limit section
- Reference -> Server SDKs p-> Send -> Parameters -> Size Limitation

![Screenshot 2025-01-30 at 7 01 52 PM](https://github.com/user-attachments/assets/f5ceb549-5465-4aae-b0c1-c1c2761683a7)

<img width="1218" alt="Screenshot 2025-01-31 at 10 14 51 AM" src="https://github.com/user-attachments/assets/1f2d8c9c-555a-4167-b49d-9f1605081960" />
