### PR TITLE
Nodejs update

### DIFF
--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -327,21 +327,42 @@ end
 
 2. Initialize:
 
-```ruby
-notificationapi = NotificationAPI.new("CLIENT_ID", "CLIENT_SECRET")
+```js
+notificationapi = NotificationAPI.new('CLIENT_ID', 'CLIENT_SECRET');
 ```
 
 </TabItem>
 </Tabs>
 
-| Name              | Type   | Description                                                                                                           |
-| ----------------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
-| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).      |
-| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments). |
-| `options`         | object | Additional initialization                                                                                             |
-| `options.baseUrl` | string | To choose a different region than default (US). Use https://api.ca.notificationapi.com to access the Canada region.   |
+| Name              | Type              | Description                                                                                                                                                                                                                               |
+| ----------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_ID`\*     | string            | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                          |
+| `CLIENT_SECRET`\* | string            | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                     |
+| `config`          | InitConfiguration | Optional configuration object for additional initialization options                                                                                                                                                                       |
+| `config.baseURL`  | string \| Region  | To choose a different region than default (US).<br/> Can be a region constant (e.g. Region.EU_REGION or Region.CA_REGION)<br/> or a custom URL string (e.g. 'https://api.eu.notificationapi.com' or 'https://api.ca.notificationapi.com') |
 
 \* required
+
+Region specific example using imported Region:
+
+```js
+import notificationapi from 'notificationapi-node-server-sdk';
+import { Region } from 'notificationapi-node-server-sdk';
+
+notificationapi = NotificationAPI.new('CLIENT_ID', 'CLIENT_SECRET', {
+  baseURL: Region.EU_REGION
+});
+```
+
+Region specific example using string:
+
+```js
+import notificationapi from 'notificationapi-node-server-sdk';
+
+notificationapi = NotificationAPI.new('CLIENT_ID', 'CLIENT_SECRET', {
+  baseURL: 'https://api.eu.notificationapi.com'
+});
+```
 
 ## send
 

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -78,12 +78,12 @@ import notificationapi from 'notificationapi-node-server-sdk';
 notificationapi.init('CLIENT_ID', 'CLIENT_SECRET');
 ```
 
-| Name              | Type              | Description                                                                                                                                                                                                                               |
-| ----------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CLIENT_ID`\*     | string            | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                          |
-| `CLIENT_SECRET`\* | string            | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                     |
-| `config`          | InitConfiguration | Optional configuration object for additional initialization options                                                                                                                                                                       |
-| `config.baseURL`  | string \| Region  | To choose a different region than default (US).<br/> Can be a region constant (e.g. Region.EU_REGION or Region.CA_REGION)<br/> or a custom URL string (e.g. 'https://api.eu.notificationapi.com' or 'https://api.ca.notificationapi.com') |
+| Name              | Type              | Description                                                                                                                                                                                                                                                                  |
+| ----------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_ID`\*     | string            | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                                                             |
+| `CLIENT_SECRET`\* | string            | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                                                        |
+| `config`          | InitConfiguration | Optional configuration object for additional initialization options                                                                                                                                                                                                          |
+| `config.baseURL`  | string \| Region  | To choose a different region other than default (https://api.notificationapi.com).<br/> Can be a region constant (e.g. Region.EU_REGION or Region.CA_REGION)<br/> or a custom URL string (e.g. 'https://api.eu.notificationapi.com' or 'https://api.ca.notificationapi.com') |
 
 \* required
 

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -78,6 +78,36 @@ import notificationapi from 'notificationapi-node-server-sdk';
 notificationapi.init('CLIENT_ID', 'CLIENT_SECRET');
 ```
 
+| Name              | Type              | Description                                                                                                                                                                                                                               |
+| ----------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_ID`\*     | string            | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                          |
+| `CLIENT_SECRET`\* | string            | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                     |
+| `config`          | InitConfiguration | Optional configuration object for additional initialization options                                                                                                                                                                       |
+| `config.baseURL`  | string \| Region  | To choose a different region than default (US).<br/> Can be a region constant (e.g. Region.EU_REGION or Region.CA_REGION)<br/> or a custom URL string (e.g. 'https://api.eu.notificationapi.com' or 'https://api.ca.notificationapi.com') |
+
+\* required
+
+Region specific example using imported Region:
+
+```js
+import notificationapi from 'notificationapi-node-server-sdk';
+import { Region } from 'notificationapi-node-server-sdk';
+
+notificationapi = NotificationAPI.new('CLIENT_ID', 'CLIENT_SECRET', {
+  baseURL: Region.EU_REGION
+});
+```
+
+Region specific example using string:
+
+```js
+import notificationapi from 'notificationapi-node-server-sdk';
+
+notificationapi = NotificationAPI.new('CLIENT_ID', 'CLIENT_SECRET', {
+  baseURL: 'https://api.eu.notificationapi.com'
+});
+```
+
 </TabItem>
 <TabItem value="python">
 
@@ -99,6 +129,15 @@ from notificationapi_python_server_sdk import (notificationapi)
 notificationapi.init("CLIENT_ID", "CLIENT_SECRET")
 ```
 
+| Name              | Type   | Description                                                                                                           |
+| ----------------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).      |
+| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments). |
+| `options`         | object | Additional initialization options                                                                                     |
+| `options.baseURL` | string | To choose a different region than default (US). Use https://api.ca.notificationapi.com to access the Canada region.   |
+
+\* required
+
 </TabItem>
 <TabItem value="php">
 
@@ -119,6 +158,15 @@ use NotificationAPI\NotificationAPI;
 ```php
 $notificationapi = new NotificationAPI('CLIENT_ID', 'CLIENT_SECRET');
 ```
+
+| Name              | Type   | Description                                                                                                           |
+| ----------------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).      |
+| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments). |
+| `options`         | object | Additional initialization options                                                                                     |
+| `options.baseURL` | string | To choose a different region than default (US). Use https://api.ca.notificationapi.com to access the Canada region.   |
+
+\* required
 
 </TabItem>
 <TabItem value="laravel">
@@ -185,6 +233,15 @@ class MyNotification extends Notification
 }
 ```
 
+| Name              | Type   | Description                                                                                                           |
+| ----------------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).      |
+| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments). |
+| `options`         | object | Additional initialization options                                                                                     |
+| `options.baseURL` | string | To choose a different region than default (US). Use https://api.ca.notificationapi.com to access the Canada region.   |
+
+\* required
+
 </TabItem>
 <TabItem value="go">
 
@@ -208,6 +265,15 @@ import (
 notificationapi.Init("CLIENT_ID", "CLIENT_SECRET")
 ```
 
+| Name              | Type   | Description                                                                                                           |
+| ----------------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).      |
+| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments). |
+| `options`         | object | Additional initialization options                                                                                     |
+| `options.baseURL` | string | To choose a different region than default (US). Use https://api.ca.notificationapi.com to access the Canada region.   |
+
+\* required
+
 </TabItem>
 <TabItem value="csharp">
 
@@ -229,6 +295,15 @@ using NotificationApi.Server.Models;
 ```csharp
 var notificationApi = new NotificationApiServer("CLIENT_ID", "CLIENT_SECRET", false);
 ```
+
+| Name              | Type   | Description                                                                                                           |
+| ----------------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).      |
+| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments). |
+| `options`         | object | Additional initialization options                                                                                     |
+| `options.baseURL` | string | To choose a different region than default (US). Use https://api.ca.notificationapi.com to access the Canada region.   |
+
+\* required
 
 </TabItem>
 <TabItem value="ruby">
@@ -331,38 +406,17 @@ end
 notificationapi = NotificationAPI.new('CLIENT_ID', 'CLIENT_SECRET');
 ```
 
-</TabItem>
-</Tabs>
-
-| Name              | Type              | Description                                                                                                                                                                                                                               |
-| ----------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CLIENT_ID`\*     | string            | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                          |
-| `CLIENT_SECRET`\* | string            | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                     |
-| `config`          | InitConfiguration | Optional configuration object for additional initialization options                                                                                                                                                                       |
-| `config.baseURL`  | string \| Region  | To choose a different region than default (US).<br/> Can be a region constant (e.g. Region.EU_REGION or Region.CA_REGION)<br/> or a custom URL string (e.g. 'https://api.eu.notificationapi.com' or 'https://api.ca.notificationapi.com') |
+| Name              | Type   | Description                                                                                                           |
+| ----------------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).      |
+| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments). |
+| `options`         | object | Additional initialization options                                                                                     |
+| `options.baseURL` | string | To choose a different region than default (US). Use https://api.ca.notificationapi.com to access the Canada region.   |
 
 \* required
 
-Region specific example using imported Region:
-
-```js
-import notificationapi from 'notificationapi-node-server-sdk';
-import { Region } from 'notificationapi-node-server-sdk';
-
-notificationapi = NotificationAPI.new('CLIENT_ID', 'CLIENT_SECRET', {
-  baseURL: Region.EU_REGION
-});
-```
-
-Region specific example using string:
-
-```js
-import notificationapi from 'notificationapi-node-server-sdk';
-
-notificationapi = NotificationAPI.new('CLIENT_ID', 'CLIENT_SECRET', {
-  baseURL: 'https://api.eu.notificationapi.com'
-});
-```
+</TabItem>
+</Tabs>
 
 ## send
 


### PR DESCRIPTION
Update docs for nodejs with more info for region specifics for customers.

Tested both methods for regions using both the string and region methods and all working. Updated docs to show example for customers using both methods for reference points.

Breakout the table section that included the values from a generic set to a individual library set now that can be customized for each package as needed as each package will have a little bit of a different setup for region specifics to show examples.