### PR TITLE
Update PHP instructions to support all regions

### DIFF
--- a/docs/quick-start/send-a-notification.md
+++ b/docs/quick-start/send-a-notification.md
@@ -262,6 +262,8 @@ asyncio.run(send_notification())
 use NotificationAPI\NotificationAPI;
 
 # init
+# if in the CA Region, add 'https://api.ca.notificationapi.com' after Client Secret
+# if in the EU Region, add 'https://api.eu.notificationapi.com' after Client Secret
 $notificationapi = new NotificationAPI('CLIENT_ID', 'CLIENT_SECRET');
 
 # send
@@ -273,6 +275,7 @@ $notificationapi->send([
     "user" => [
         "id" => "spongebob.squarepants",
         "email" => "spongebob@squarepants.com",   # required for email notifications
+        "number" => "+15005550006" # optional phone number required to send SMS notifications
     ],
     # mergeTags is to pass dynamic values into the notification design.
     "mergeTags" => [

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -172,13 +172,29 @@ use NotificationAPI\NotificationAPI;
 $notificationapi = new NotificationAPI('CLIENT_ID', 'CLIENT_SECRET');
 ```
 
-| Name              | Type   | Description                                                                                                                                                                         |
-| ----------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).                                                                    |
-| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments).                                                               |
-| `baseURL`         | string | To configure a different region other than default (US). Use 'https://api.ca.notificationapi.com' for the Canada region, or 'https://api.eu.notificationapi.com' for the EU region. |
+| Name              | Type   | Description                                                                                                                                                                                                                                                |
+| ----------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                                           |
+| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                                      |
+| `baseURL`         | string | To choose a different region than default US region (https://api.notificationapi.com). Can be a public region constant (e.g. NotificationAPI::EU_REGION or NotificationAPI::CA_REGION) or a custom URL string (e.g. 'https://api.eu.notificationapi.com'). |
 
 \* required
+
+Region specific example using public region constant:
+
+```python
+use NotificationAPI\NotificationAPI;
+
+notificationapi.init("CLIENT_ID", "CLIENT_SECRET", NotificationAPI::EU_REGION)
+```
+
+Region specific example using string:
+
+```js
+use NotificationAPI\NotificationAPI;
+
+notificationapi = NotificationAPI.new("CLIENT_ID", "CLIENT_SECRET", "https://api.eu.notificationapi.com");
+```
 
 </TabItem>
 <TabItem value="laravel">

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -172,12 +172,11 @@ use NotificationAPI\NotificationAPI;
 $notificationapi = new NotificationAPI('CLIENT_ID', 'CLIENT_SECRET');
 ```
 
-| Name              | Type   | Description                                                                                                           |
-| ----------------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
-| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).      |
-| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments). |
-| `options`         | object | Additional initialization options                                                                                     |
-| `options.baseURL` | string | To choose a different region than default (US). Use https://api.ca.notificationapi.com to access the Canada region.   |
+| Name              | Type   | Description                                                                                                                                                                         |
+| ----------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).                                                                    |
+| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments).                                                               |
+| `baseURL`         | string | To configure a different region other than default (US). Use 'https://api.ca.notificationapi.com' for the Canada region, or 'https://api.eu.notificationapi.com' for the EU region. |
 
 \* required
 


### PR DESCRIPTION
- Update the Quick Start to provide the CA and EU baseURLs in the comments
- Update the Server SDK reference PHP reference guide to include the EU baseURL
- Update the Server SDK reference PHP reference guide to remove the options object since it isn't required to provide the baseURL

<img width="1508" alt="Screenshot 2025-04-02 at 11 40 43 AM" src="https://github.com/user-attachments/assets/bedb199d-eb97-4cfd-868e-c7c12f87706e" />
<img width="1511" alt="Screenshot 2025-04-02 at 11 41 14 AM" src="https://github.com/user-attachments/assets/7475f352-76c4-47f8-b74f-0b7f6a6adef4" />
