### PR TITLE
Update Go examples and guide to support all regions

### DIFF
--- a/docs/quick-start/send-a-notification.md
+++ b/docs/quick-start/send-a-notification.md
@@ -299,24 +299,27 @@ import (
 )
 
 func main() {
-  // init
-  notificationapi.Init("CLIENT_ID", "CLIENT_SECRET")
+  // init (US region)
+  // if in CA Region, replace API URL with 'https://api.ca.notificationapi.com'
+  // if in EU Region, replace API URL with 'https://api.eu.notificationapi.com'
+  notificationapi.Init("CLIENT_ID", "CLIENT_SECRET", "https://api.notificationapi.com")
 
-  //mergeTags is to pass dynamic values into the notification design.
-  mergeTags := make(map[string]interface{}) // Change to map[string]interface{}
+  // mergeTags is to pass dynamic values into the notification design.
+  mergeTags := make(map[string]interface{})
   mergeTags["item"] = "Krabby Patty Burger"
   mergeTags["address"] = "124 Conch Street"
   mergeTags["orderId"] = "1234567890"
 
   notificationapi.Send(
     notificationapi.SendRequest{
-      //The ID of the notification you wish to send. You can find this
-      //value from the dashboard.
+      // The ID of the notification you wish to send. You can find this
+      // value from the dashboard.
       NotificationId: "order_tracking",
-      //The user to send the notification to.
+      // The user to send the notification to.
       User: notificationapi.User{
         Id:     "spongebob.squarepants",
         Email:  "spongebob@squarepants.com",
+        Number: "+15005550006" // Optional phone number required to send SMS notifications
       },
       MergeTags: mergeTags,
     },

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -182,7 +182,7 @@ $notificationapi = new NotificationAPI('CLIENT_ID', 'CLIENT_SECRET');
 
 Region specific example using public region constant:
 
-```python
+```php
 use NotificationAPI\NotificationAPI;
 
 notificationapi.init("CLIENT_ID", "CLIENT_SECRET", NotificationAPI::EU_REGION)
@@ -190,7 +190,7 @@ notificationapi.init("CLIENT_ID", "CLIENT_SECRET", NotificationAPI::EU_REGION)
 
 Region specific example using string:
 
-```js
+```php
 use NotificationAPI\NotificationAPI;
 
 notificationapi = NotificationAPI.new("CLIENT_ID", "CLIENT_SECRET", "https://api.eu.notificationapi.com");
@@ -290,17 +290,32 @@ import (
 3. Initialize:
 
 ```go
-notificationapi.Init("CLIENT_ID", "CLIENT_SECRET")
+notificationapi.Init("CLIENT_ID", "CLIENT_SECRET", "base_url")
 ```
 
-| Name              | Type   | Description                                                                                                           |
-| ----------------- | ------ | --------------------------------------------------------------------------------------------------------------------- |
-| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).      |
-| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments). |
-| `options`         | object | Additional initialization options                                                                                     |
-| `options.baseURL` | string | To choose a different region than default (US). Use https://api.ca.notificationapi.com to access the Canada region.   |
+| Name              | Type   | Description                                                                                                                                                                                                                                                                        |
+| ----------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CLIENT_ID`\*     | string | Your NotificationAPI account clientId. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                                                                   |
+| `CLIENT_SECRET`\* | string | Your NotificationAPI account client secret. You can get it from [here](https://app.notificationapi.com/environments).                                                                                                                                                              |
+| `base_url`\*      | string | To set the region. Use https://api.notificationapi.com for US region, https://api.ca.notificationapi.com for Canada region, and https://api.eu.notificationapi.com for EU region. Can also use region constants US_REGION, CA_REGION or EU_REGION (e.g. notificationapi.US_REGION) |
 
 \* required
+
+Region specific example using public region constant:
+
+```Go
+use NotificationAPI\NotificationAPI;
+
+notificationapi.init("CLIENT_ID", "CLIENT_SECRET", notificationapi.EU_REGION)
+```
+
+Region specific example using string:
+
+```Go
+use NotificationAPI\NotificationAPI;
+
+notificationapi = NotificationAPI.new("CLIENT_ID", "CLIENT_SECRET", "https://api.eu.notificationapi.com");
+```
 
 </TabItem>
 <TabItem value="csharp">


### PR DESCRIPTION
- Update quick start guide to initialize with default US region and include comments about CA and EU api urls
- Correct PHP region specific examples to indicate it's PHP code
- Update Go guide to include required base_url and possible values
- Add region specific initialization examples with region options