### PR TITLE
docs(webhook): update webhook documentation with new features and improvements

### DIFF
--- a/docs/features/events-webhook.md
+++ b/docs/features/events-webhook.md
@@ -61,17 +61,6 @@ To receive notification events:
 4. Implement proper validation of incoming webhook requests
 5. Process and store the event data as needed for your use case
 
-<!--
-## Security Considerations
-
-To ensure that webhook requests are legitimate:
-
-- Verify webhook signatures (documentation coming soon)
-- Use HTTPS for your endpoint
-- Implement appropriate authentication and authorization
-- Consider rate limiting and request validation
--->
-
 ## FAQ
 
 **Q: What is the format of the webhook requests?**  

--- a/docs/features/events-webhook.md
+++ b/docs/features/events-webhook.md
@@ -45,10 +45,11 @@ You can easily configure your webhook endpoints and select which events to track
 
 The webhook currently supports the following notification events:
 
-| Event         | Description                                                       | Payload                                                                                                |
-| ------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `EMAIL_OPEN`  | Triggered when a recipient opens an email notification            | `{ eventType: "OPEN", trackingId: string, notificationId: string, channel: "EMAIL", userId: string }`  |
-| `EMAIL_CLICK` | Triggered when a recipient clicks a link in an email notification | `{ eventType: "CLICK", trackingId: string, notificationId: string, channel: "EMAIL", userId: string }` |
+| Event         | Description                                                           | Payload                                                                                                  |
+| ------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `EMAIL_OPEN`  | Triggered when a recipient opens an email notification                | `{ eventType: "OPEN", trackingId: string, notificationId: string, channel: "EMAIL", userId: string }`    |
+| `EMAIL_CLICK` | Triggered when a recipient clicks a link in an email notification     | `{ eventType: "CLICK", trackingId: string, notificationId: string, channel: "EMAIL", userId: string }`   |
+| `FAILED`      | Triggered when a notification fails to deliver (for any channel type) | `{ eventType: "FAILED", trackingId: string, notificationId: string, channel: Channels, userId: string }` |
 
 ## Setting Up Your Webhook
 
@@ -56,7 +57,7 @@ To receive notification events:
 
 1. Create a publicly accessible API endpoint that can receive HTTP POST requests
 2. Configure your webhook URL in the NotificationAPI dashboard
-3. Select which events you want to receive (EMAIL_OPEN, EMAIL_CLICK)
+3. Select which events you want to receive (EMAIL_OPEN, EMAIL_CLICK, FAILED)
 4. Implement proper validation of incoming webhook requests
 5. Process and store the event data as needed for your use case
 
@@ -77,10 +78,13 @@ To ensure that webhook requests are legitimate:
 A: Webhook requests are sent as HTTP POST requests with JSON payloads containing event details such as eventType, trackingId, notificationId, channel, and userId.
 
 **Q: Can I filter which events I receive?**  
-A: Yes, you can select which events to receive (EMAIL_OPEN, EMAIL_CLICK) in the dashboard configuration.
+A: Yes, you can select which events to receive (EMAIL_OPEN, EMAIL_CLICK, FAILED) in the dashboard configuration.
 
 **Q: What response should my endpoint return?**  
 A: Your endpoint should return a 2xx HTTP status code to acknowledge successful receipt of the webhook.
+
+**Q: When would I receive a FAILED event?**  
+A: You'll receive a FAILED event whenever a notification on any channel (email, SMS, push, etc.) fails to deliver to the recipient. This could happen for various reasons like invalid recipient details, network issues, service provider failures, or user-specific delivery problems. This event helps you track delivery failures across all your notification channels.
 
 **Q: Can I delete or update my webhook configuration?**  
 A: Yes, you can update your webhook URL or selected events at any time from the dashboard. You can also delete your webhook configuration if you no longer need it.

--- a/docs/features/events-webhook.md
+++ b/docs/features/events-webhook.md
@@ -1,6 +1,6 @@
-# 🪝 Webhook API
+# 🪝 Events Webhook
 
-The Notification Events Webhook API allows you to receive real-time updates about notification events such as delivery, opens, and clicks. By setting up a publicly accessible API endpoint, you can track and react to these events programmatically.
+The Notification Events Webhook allows you to receive real-time updates about notification events such as delivery, opens, and clicks. By setting up a publicly accessible API endpoint, you can track and react to these events programmatically.
 
 :::note
 This feature is currently in beta.
@@ -39,9 +39,11 @@ You can easily configure your webhook endpoints and select which events to track
 3. Select the events you want to receive notifications for
 4. Click "Save Configuration"
 
+<!-- Image will be added later -->
+
 ## Supported Events
 
-The webhook API currently supports the following notification events:
+The webhook currently supports the following notification events:
 
 | Event         | Description                                                       | Payload                                                                                                |
 | ------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
@@ -57,6 +59,17 @@ To receive notification events:
 3. Select which events you want to receive (EMAIL_OPEN, EMAIL_CLICK)
 4. Implement proper validation of incoming webhook requests
 5. Process and store the event data as needed for your use case
+
+<!--
+## Security Considerations
+
+To ensure that webhook requests are legitimate:
+
+- Verify webhook signatures (documentation coming soon)
+- Use HTTPS for your endpoint
+- Implement appropriate authentication and authorization
+- Consider rate limiting and request validation
+-->
 
 ## FAQ
 


### PR DESCRIPTION
## Changes
- Renamed file from `webhook-api.md` to `events-webhook.md` to better reflect its purpose
- Renamed title from "Webhook API" to "Events Webhook" for consistency
- Added support for the `FAILED` event type with description and payload information
- Updated FAQ section with information about the FAILED event
- Added placeholder for security considerations section
- Improved formatting and clarity throughout the document

## Additional Notes
This PR updates the webhook documentation to include new features and improvements, particularly adding documentation for the FAILED event type that notifies when notifications fail to deliver across any channel.